### PR TITLE
Remove nested dependency tree

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ all: image
 	docker push $(IMAGE_TAG)
 
 setup:
-	glide install
+	glide install -v
 
 build:
 	$(GO) build -a -installsuffix cgo -o $(BIN) .


### PR DESCRIPTION
Some dependency library is causing this problem of 
```
./worker_cleaner flag redefined: log_dir
panic: ./worker_cleaner flag redefined: log_dir
```
Set `-v` flag in `glide install` to remove the nested dependencies